### PR TITLE
Update RNNRootViewController.m

### DIFF
--- a/lib/ios/RNNRootViewController.m
+++ b/lib/ios/RNNRootViewController.m
@@ -62,6 +62,13 @@
 -(void)viewWillAppear:(BOOL)animated{
 	[super viewWillAppear:animated];
 	_isBeingPresented = YES;
+	if (self.navigationController) {
+		if ([self.navigationController viewControllers].firstObject == self) {
+			if (self.options.bottomTabs && self.options.bottomTabs.visible && ![self.options.bottomTabs.visible boolValue]) {
+				[self.tabBarController.tabBar setHidden:YES];
+			}
+		}
+	}
 	[self.options applyOn:self];
 }
 


### PR DESCRIPTION
Resolve the problem for the initial selected screen of tabBarController with the bottomTabs visibility set 'false' but the tabbar still shown.